### PR TITLE
This is a hack to synch up the rendering and AR projection matrices and camera parameters.

### DIFF
--- a/scene/3d/arvr_nodes.cpp
+++ b/scene/3d/arvr_nodes.cpp
@@ -43,6 +43,7 @@ void ARVRCamera::_notification(int p_what) {
 			if (origin != NULL) {
 				origin->set_tracked_camera(this);
 			}
+			set_process(true);
 		}; break;
 		case NOTIFICATION_EXIT_TREE: {
 			// need to find our ARVROrigin parent and let it know we're no longer it's camera!
@@ -50,6 +51,19 @@ void ARVRCamera::_notification(int p_what) {
 			if (origin != NULL) {
 				origin->clear_tracked_camera_if(this);
 			}
+			set_process(false);
+		}; break;
+		case NOTIFICATION_PROCESS: {
+			// Get the current projection matrix and send it to the visual server.  This doesn't feel like it
+			// is proper, but will consult with Godot folks and figure out how to do this properly later.
+			ARVRServer *arvr_server = ARVRServer::get_singleton();
+			Ref<ARVRInterface> arvr_interface = arvr_server->get_primary_interface();
+			// Get the current projection matrix and send it to the visual server
+			Size2 viewport_size = get_viewport()->get_camera_rect_size();
+			CameraMatrix cm = arvr_interface->get_projection_for_eye(ARVRInterface::EYE_MONO, viewport_size.aspect(), get_znear(), get_zfar());
+			set_znear(cm.get_z_near());
+			set_zfar(cm.get_z_far());
+			VisualServer::get_singleton()->camera_set_perspective(get_camera(), cm.get_fov(), get_znear(), get_zfar());
 		}; break;
 	};
 };


### PR DESCRIPTION
Bastiaan:

This isn't a serious pull request at the moment, I just wanted to get your opinion on how I would do this cleaner.

The issue is that in the current ARKit branch the projection matrices that are being sent back from ARKit are not used by the ARVRCamera. To fix this, I'm basically polling the arvr interface and setting the ARVRCamera parameters to match ARKit.  This is working ok, but I imagine it'll cause issues for VR.  Also, it'd be sweet to allow setting of near and far planes from the Godot side.  

So, there are two issues: 

1.  Setting the near and far planes for AR:  Should we just add a setNear/setFar onto ARVRInterface?  That way ARKitInterface will have that info in the process method when it figures out the projectionmatrix.
2. Updating the ARVRCamera when the parameters change.  Isn't this an issue with VR at the moment too?  It looks like there's no information flowing back from the ARVRInterface telling the camera about FOV.  How do you think this should work?

Thanks for taking time to look into this.
Brian