### PR TITLE
Fix: rename src. Skipped scons warning causes compilation error

### DIFF
--- a/modules/arcore/SCSub
+++ b/modules/arcore/SCSub
@@ -1,9 +1,0 @@
-#!/usr/bin/env python
-
-Import('env')
-Import('env_modules')
-
-env_arcore = env_modules.Clone()
-
-# Add source files
-env_arcore.add_source_files(env.modules_sources, "*.cpp")


### PR DESCRIPTION
Maybe handle  this type  of scons warning more strictly:
> scons: warning: Ignoring missing SConscript 'modules/arcore/SCsub'