### PR TITLE
Improve ARCore setup logic.

### DIFF
--- a/misc/ide/jetbrains/build.gradle
+++ b/misc/ide/jetbrains/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
     implementation "com.android.support:support-core-utils:28.0.0"
+    implementation "com.google.ar:core:1.10.0"
 }
 
 def pathToRootDir = "../../../"

--- a/modules/arcore/arcore_interface.h
+++ b/modules/arcore/arcore_interface.h
@@ -52,8 +52,6 @@ public:
 	enum InitStatus {
 		NOT_INITIALISED, // We're not initialised
 		START_INITIALISE, // We just started our initialise process
-		REQUESTED_CAMERA, // We are waiting on our camera
-		WAITING_ON_INSTALL, // We are waiting on ARCore being installed
 		INITIALISED, // Yeah! we are up and running
 		INITIALISE_FAILED // We failed to initialise
 	};
@@ -91,6 +89,7 @@ protected:
 
 public:
 	void _resume();
+	void _pause();
 
 	virtual StringName get_name() const;
 	virtual int get_capabilities() const;

--- a/platform/android/java/AndroidManifest.xml
+++ b/platform/android/java/AndroidManifest.xml
@@ -28,9 +28,6 @@
 <!--The following values are replaced when Godot exports, modifying them here has no effect. Do these changes in the-->
 <!--export preset. Adding new ones is fine.-->
 
-<!--ARCore meta data. This is modified by the exporter based on whether ARCore is enabled -->
-        <meta-data android:name="com.google.ar.core" android:value="arcore_required" />
-
 <!-- XR mode metadata. This is modified by the exporter based on the selected xr mode. DO NOT CHANGE the values here. -->
         <meta-data android:name="xr_mode_metadata_name" android:value="xr_mode_metadata_value"/>
 
@@ -48,6 +45,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity android:name="org.godotengine.godot.xr.arcore.ARCoreSetupActivity"
+                  android:label="@string/godot_arcore_setup_activity_label"
+                  android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen"
+                  android:screenOrientation="landscape"/>
 
     <service android:name="org.godotengine.godot.GodotDownloaderService" />
 

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -31,7 +31,7 @@ allprojects {
 dependencies {
 	implementation "com.android.support:support-core-utils:28.0.0"
 //ARCore specific, needs to become options
-	implementation 'com.google.ar:core:1.7.0'
+	implementation "com.google.ar:core:1.10.0"
 //CHUNK_DEPENDENCIES_BEGIN
 //CHUNK_DEPENDENCIES_END
 }

--- a/platform/android/java/res/values/strings.xml
+++ b/platform/android/java/res/values/strings.xml
@@ -52,4 +52,9 @@
     <string name="kilobytes_per_second">%1$s KB/s</string>
     <string name="time_remaining">Time remaining: %1$s</string>
     <string name="time_remaining_notification">%1$s left</string>
+
+    <!-- AR Core related strings -->
+    <string name="godot_arcore_setup_activity_label">Godot ARCore Setup</string>
+    <string name="setup_arcore_request">Please setup ARCore to use the app</string>
+    <string name="missing_camera_permission_warning">Camera permission is needed to run this application</string>
 </resources>

--- a/platform/android/java/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/src/org/godotengine/godot/Godot.java
@@ -68,10 +68,7 @@ import android.view.ViewGroup.LayoutParams;
 import android.view.ViewTreeObserver;
 import android.view.Window;
 import android.view.WindowManager;
-import android.widget.Button;
-import android.widget.FrameLayout;
-import android.widget.ProgressBar;
-import android.widget.TextView;
+import android.widget.*;
 import com.google.android.vending.expansion.downloader.DownloadProgressInfo;
 import com.google.android.vending.expansion.downloader.DownloaderClientMarshaller;
 import com.google.android.vending.expansion.downloader.DownloaderServiceMarshaller;
@@ -92,6 +89,7 @@ import javax.microedition.khronos.opengles.GL10;
 import org.godotengine.godot.input.GodotEditText;
 import org.godotengine.godot.payments.PaymentsManager;
 import org.godotengine.godot.xr.XRMode;
+import org.godotengine.godot.xr.arcore.ARCoreUtil;
 
 public class Godot extends Activity implements SensorEventListener, IDownloaderClient {
 
@@ -497,6 +495,8 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 					xrMode = XRMode.REGULAR;
 				} else if (command_line[i].equals(XRMode.OVR.cmdLineArg)) {
 					xrMode = XRMode.OVR;
+				} else if (command_line[i].equals(XRMode.ARCORE.cmdLineArg)) {
+					xrMode = XRMode.ARCORE;
 				} else if (command_line[i].equals("--use_depth_32")) {
 					use_32_bits = true;
 				} else if (command_line[i].equals("--debug_opengl")) {
@@ -614,9 +614,13 @@ public class Godot extends Activity implements SensorEventListener, IDownloaderC
 
 		mCurrentIntent = getIntent();
 
-		initializeGodot();
+		// Check that ARCore is properly setup before progressing.
+		if (ARCoreUtil.shouldSetupARCore(this, xrMode)) {
+			ARCoreUtil.setupARCore(this, mCurrentIntent);
+			return;
+		}
 
-		//instanceSingleton( new GodotFacebook(this) );
+		initializeGodot();
 	}
 
 	@Override

--- a/platform/android/java/src/org/godotengine/godot/GodotView.java
+++ b/platform/android/java/src/org/godotengine/godot/GodotView.java
@@ -124,6 +124,7 @@ public class GodotView extends GLSurfaceView {
 				break;
 
 			case REGULAR:
+			case ARCORE:
 			default:
 				/* By default, GLSurfaceView() creates a RGB_565 opaque surface.
 				 * If we want a translucent one, we should change the surface's

--- a/platform/android/java/src/org/godotengine/godot/xr/XRMode.java
+++ b/platform/android/java/src/org/godotengine/godot/xr/XRMode.java
@@ -35,7 +35,8 @@ package org.godotengine.godot.xr;
  */
 public enum XRMode {
 	REGULAR(0, "Regular", "--xr_mode_regular"), // Regular/flatscreen
-	OVR(1, "Oculus Mobile VR", "--xr_mode_ovr");
+	OVR(1, "Oculus Mobile VR", "--xr_mode_ovr"),
+	ARCORE(2, "AR Core", "--xr_mode_arcore");
 
 	final int index;
 	final String label;

--- a/platform/android/java/src/org/godotengine/godot/xr/arcore/ARCoreSetupActivity.java
+++ b/platform/android/java/src/org/godotengine/godot/xr/arcore/ARCoreSetupActivity.java
@@ -1,0 +1,110 @@
+/*************************************************************************/
+/*  ARCoreSetupActivity.java                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+package org.godotengine.godot.xr.arcore;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Toast;
+import com.godot.game.R;
+import com.google.ar.core.ArCoreApk;
+import com.google.ar.core.exceptions.UnavailableDeviceNotCompatibleException;
+import com.google.ar.core.exceptions.UnavailableUserDeclinedInstallationException;
+import org.godotengine.godot.Godot;
+
+/**
+ * Activity used to setup ARCore prior to initializing the Godot engine.
+ */
+public class ARCoreSetupActivity extends Activity {
+
+	static final String PREVIOUS_ACTIVITY_START_INTENT_KEY = "previous_activity_start_intent";
+
+	private static boolean requestARCoreInstall = true;
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		setContentView(new View(this));
+	}
+
+	@Override
+	public void onResume() {
+		super.onResume();
+
+		// Check that ARCore is installed and up-to-date.
+		try {
+			switch (ArCoreApk.getInstance().requestInstall(this, requestARCoreInstall)) {
+				case INSTALLED:
+					break;
+				case INSTALL_REQUESTED:
+					requestARCoreInstall = false;
+					return;
+			}
+
+			// Request CAMERA permission if needed.
+			if (!ARCoreUtil.hasCameraPermission(this)) {
+				ARCoreUtil.requestCameraPermission(this);
+				return;
+			}
+
+			// We have everything we need. Let's restart the original activity.
+			Intent previousIntent = null;
+			if (getIntent() != null) {
+				previousIntent = getIntent().getParcelableExtra(PREVIOUS_ACTIVITY_START_INTENT_KEY);
+			}
+			if (previousIntent == null) {
+				previousIntent = new Intent(this, Godot.class);
+			}
+
+			startActivity(previousIntent);
+
+		} catch (UnavailableUserDeclinedInstallationException | UnavailableDeviceNotCompatibleException e) {
+			Toast.makeText(this, R.string.setup_arcore_request, Toast.LENGTH_LONG).show();
+		}
+
+		finish();
+	}
+
+	@Override
+	public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+		if (ARCoreUtil.isARCoreRequestPermissionCode(requestCode)) {
+			if (!ARCoreUtil.hasCameraPermission(this)) {
+				Toast.makeText(this, R.string.missing_camera_permission_warning, Toast.LENGTH_LONG).show();
+				if (!ARCoreUtil.shouldShowRequestPermissionRationale(this)) {
+					// Permission denied with checking "Do not ask again".
+					ARCoreUtil.launchPermissionSettings(this);
+				}
+				finish();
+			}
+		}
+	}
+}

--- a/platform/android/java/src/org/godotengine/godot/xr/arcore/ARCoreUtil.java
+++ b/platform/android/java/src/org/godotengine/godot/xr/arcore/ARCoreUtil.java
@@ -1,0 +1,112 @@
+/*************************************************************************/
+/*  ARCoreUtil.java                                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+package org.godotengine.godot.xr.arcore;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.provider.Settings;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+import com.google.ar.core.ArCoreApk;
+import org.godotengine.godot.xr.XRMode;
+
+/**
+ * AR Core related utility methods.
+ */
+public final class ARCoreUtil {
+
+	private static final int CAMERA_PERMISSION_CODE = 4324;
+	private static final String CAMERA_PERMISSION = Manifest.permission.CAMERA;
+
+	private ARCoreUtil() {
+	}
+
+	/**
+     * Returns true if we should start the process of setting up ARCore for the app.
+     * <p>
+     * This usually occurs when {@link XRMode#ARCORE} is the XR mode, but CAMERA permission
+     * is missing or ARCore is not installed or up-to-date.
+     */
+	public static boolean shouldSetupARCore(Activity activity, XRMode xrMode) {
+		// Validate we have the correct XR mode.
+		if (XRMode.ARCORE != xrMode) {
+			return false;
+		}
+
+		// Check if the CAMERA permission is available.
+		if (!hasCameraPermission(activity)) {
+			return true;
+		}
+
+		// Check that ARCore is installed and up-to-date.
+		return ArCoreApk.getInstance().checkAvailability(activity) != ArCoreApk.Availability.SUPPORTED_INSTALLED;
+	}
+
+	/**
+     * Launches the {@link ARCoreSetupActivity} to initiate the setup process for ARCore.
+     */
+	public static void setupARCore(Activity activity, Intent previousActivityStartIntent) {
+		activity.startActivity(new Intent(activity, ARCoreSetupActivity.class)
+									   .putExtra(ARCoreSetupActivity.PREVIOUS_ACTIVITY_START_INTENT_KEY, previousActivityStartIntent));
+		activity.finish();
+	}
+
+	static boolean isARCoreRequestPermissionCode(int requestCode) {
+		return requestCode == CAMERA_PERMISSION_CODE;
+	}
+
+	/** Check to see we have the necessary permissions for this app. */
+	static boolean hasCameraPermission(Activity activity) {
+		return ContextCompat.checkSelfPermission(activity, CAMERA_PERMISSION) == PackageManager.PERMISSION_GRANTED;
+	}
+
+	/** Check to see we have the necessary permissions for this app, and ask for them if we don't. */
+	static void requestCameraPermission(Activity activity) {
+		ActivityCompat.requestPermissions(
+				activity, new String[] { CAMERA_PERMISSION }, CAMERA_PERMISSION_CODE);
+	}
+
+	/** Check to see if we need to show the rationale for this permission. */
+	static boolean shouldShowRequestPermissionRationale(Activity activity) {
+		return ActivityCompat.shouldShowRequestPermissionRationale(activity, CAMERA_PERMISSION);
+	}
+
+	/** Launch Application Setting to grant permission. */
+	static void launchPermissionSettings(Activity activity) {
+		Intent intent = new Intent();
+		intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+		intent.setData(Uri.fromParts("package", activity.getPackageName(), null));
+		activity.startActivity(intent);
+	}
+}


### PR DESCRIPTION
Most of the ARCore setup logic is moved to the java layer via the ARCoreSetupActivity.
This greatly simplifies the native layer init logic, since that layer isn't started unless ARCore is properly setup.