### PR TITLE
ARCore: Gradle fixups

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,12 +1,11 @@
 ext.versions = [
-        androidGradlePlugin : '3.4.2',
-        compileSdk : 28,
-        minSdk : 18,
-        targetSdk : 28,
-        buildTools : '28.0.3',
-
+    androidGradlePlugin : '3.4.2',
+    compileSdk : 28,
+    minSdk : 18,
+    targetSdk : 28,
+    buildTools : '28.0.3',
 ]
 
 ext.libraries = [
-        androidGradlePlugin : "com.android.tools.build:gradle:$versions.androidGradlePlugin"
+    androidGradlePlugin : "com.android.tools.build:gradle:$versions.androidGradlePlugin"
 ]

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -133,20 +133,20 @@ task generateGodotTemplates(type: GradleBuild) {
  * Clean the generated artifacts.
  */
 task cleanGodotTemplates(type: Delete) {
-	// Delete the generated native libs
-	delete("lib/libs")
+    // Delete the generated native libs
+    delete("lib/libs")
 
-	// Delete the library generated AAR files
-	delete("lib/build/outputs/aar")
+    // Delete the library generated AAR files
+    delete("lib/build/outputs/aar")
 
-	// Delete the app libs directory contents
-	delete("app/libs")
+    // Delete the app libs directory contents
+    delete("app/libs")
 
-	// Delete the generated binary apks
-	delete("app/build/outputs/apk")
+    // Delete the generated binary apks
+    delete("app/build/outputs/apk")
 
-	// Delete the Godot templates in the Godot bin directory
-	delete("$binDir/android_debug.apk")
-	delete("$binDir/android_release.apk")
-	delete("$binDir/android_source.zip")
+    // Delete the Godot templates in the Godot bin directory
+    delete("$binDir/android_debug.apk")
+    delete("$binDir/android_release.apk")
+    delete("$binDir/android_source.zip")
 }

--- a/thirdparty/arcore/extract-arcore-libs.gradle
+++ b/thirdparty/arcore/extract-arcore-libs.gradle
@@ -1,50 +1,40 @@
+apply from: '../../platform/android/java/app/config.gradle'
+
 buildscript {
-	repositories {
-		google()
-		jcenter()
+    apply from: '../../platform/android/java/app/config.gradle'
 
-	}
-	dependencies {
-		classpath 'com.android.tools.build:gradle:3.2.1'
-
-	}
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath libraries.androidGradlePlugin
+    }
 }
 
 apply plugin: 'com.android.application'
 
-def arcore_libpath = "./../../thirdparty/arcore"
-
 // Create a configuration to mark which aars to extract .so files from
 configurations { natives }
 
-
 allprojects {
     repositories {
-	mavenCentral()
-	google()
-	jcenter()
-
+        google()
+        jcenter()
+        mavenCentral()
     }
 }
 
 dependencies {
-	implementation "com.android.support:support-core-utils:28.0.0"
-	implementation 'com.google.ar:core:1.7.0'
+    implementation 'com.android.support:support-core-utils:28.0.0'
+    implementation 'com.google.ar:core:1.7.0'
     natives 'com.google.ar:core:1.7.0'
-
 }
-
 
 android {
-
-
-	compileSdkVersion 28
-	buildToolsVersion "28.0.3"
-	useLibrary 'org.apache.http.legacy'
-
-
+    compileSdkVersion versions.compileSdk
+    buildToolsVersion versions.buildTools
 }
-
 
 task extractNativeLibraries() {
     // Always extract, this insures the native libs are updated if the version changes.
@@ -53,7 +43,7 @@ task extractNativeLibraries() {
         configurations.natives.files.each { f ->
             copy {
                 from zipTree(f)
-                into arcore_libpath
+                into "."
                 include "jni/**/*"
             }
         }


### PR DESCRIPTION
I tried to clean up the new gradle file to match what @m4gr3d refactored.
My gradle-fu is limited to copy paste and trial and error, so some parts can likely be improved further.

I worked on that while trying to fix CI builds, but what's really needed for that are the changes in this PR: godotengine/godot#33082.
So once this is merged, the ARCore branch should also be rebased on master.