### PR TITLE
Treat desired Vulkan version exceeding supported OpenXR version as a warning

### DIFF
--- a/modules/openxr/extensions/openxr_vulkan_extension.cpp
+++ b/modules/openxr/extensions/openxr_vulkan_extension.cpp
@@ -122,12 +122,19 @@ bool OpenXRVulkanExtension::check_graphics_api_support(XrVersion p_desired_versi
 	print_line(" - maxApiVersionSupported: ", OpenXRUtil::make_xr_version_string(vulkan_requirements.maxApiVersionSupported));
 	// #endif
 
-	if (p_desired_version > vulkan_requirements.maxApiVersionSupported || p_desired_version < vulkan_requirements.minApiVersionSupported) {
-		print_line("OpenXR: Runtime does not support requested Vulkan version.");
+	if (p_desired_version < vulkan_requirements.minApiVersionSupported) {
+		("OpenXR: Requested Vulkan version does not meet the minimum version this runtime supports.");
 		print_line("- desired_version ", OpenXRUtil::make_xr_version_string(p_desired_version));
 		print_line("- minApiVersionSupported ", OpenXRUtil::make_xr_version_string(vulkan_requirements.minApiVersionSupported));
 		print_line("- maxApiVersionSupported ", OpenXRUtil::make_xr_version_string(vulkan_requirements.maxApiVersionSupported));
 		return false;
+	}
+
+	if (p_desired_version > vulkan_requirements.maxApiVersionSupported) {
+		print_line("OpenXR: Requested Vulkan version exceeds the maximum version this runtime has been tested on and is known to support.");
+		print_line("- desired_version ", OpenXRUtil::make_xr_version_string(p_desired_version));
+		print_line("- minApiVersionSupported ", OpenXRUtil::make_xr_version_string(vulkan_requirements.minApiVersionSupported));
+		print_line("- maxApiVersionSupported ", OpenXRUtil::make_xr_version_string(vulkan_requirements.maxApiVersionSupported));
 	}
 
 	return true;


### PR DESCRIPTION
As we discussed, changes check_graphics_api_support to not return false if the requested Vulkan version exceeded the runtime's maximum Vulkan, but will print an appropriate warning. This seems like it should make sense since the spec does not define the maximum support version as a hard requirement, just when the maximum version the runtime version has been tested against.

https://www.khronos.org/registry/OpenXR/specs/0.90/man/html/XrGraphicsRequirementsVulkanKHR.html

Should fix using Oculus' OpenXR desktop runtime since it caps its min and max Vulkan version to 1.0, but otherwise still works with Vulkan 1.2