### PR TITLE
Enable nested #include directives

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2183,6 +2183,37 @@ void MaterialStorage::_update_global_shader_uniforms() {
 	}
 }
 
+/* SHADER TEMPLATE API */
+
+void GLES3::ShaderTemplate::cleanup() {
+	if (shader) {
+		memdelete(shader);
+		shader = nullptr;
+	}
+}
+
+RID MaterialStorage::shader_template_allocate() {
+	return shader_template_owner.allocate_rid();
+}
+
+void MaterialStorage::shader_template_initialize(RID p_rid) {
+	ShaderTemplate shader_template;
+	shader_template.shader = nullptr;
+	shader_template_owner.initialize_rid(p_rid, shader_template);
+}
+
+void MaterialStorage::shader_template_free(RID p_rid) {
+	ShaderTemplate *shader_template = shader_template_owner.get_or_null(p_rid);
+	ERR_FAIL_NULL(shader_template);
+
+	shader_template->cleanup();
+	shader_template_owner.free(p_rid);
+}
+
+void MaterialStorage::shader_template_set_raster_code(RID p_template_shader, const String &p_vertex_code, const String &p_fragment_code, const String &p_name) {
+	// Not supported in compatibility (yet).
+}
+
 /* SHADER API */
 
 RID MaterialStorage::shader_allocate() {
@@ -2211,6 +2242,15 @@ void MaterialStorage::shader_free(RID p_rid) {
 		memdelete(shader->data);
 	}
 	shader_owner.free(p_rid);
+}
+
+void MaterialStorage::shader_set_shader_template(RID p_shader, RID p_shader_template, bool p_clear_code) {
+	GLES3::Shader *shader = shader_owner.get_or_null(p_shader);
+	ERR_FAIL_NULL(shader);
+
+	if (shader->shader_template != p_shader_template) {
+		shader->shader_template = p_shader_template;
+	}
 }
 
 void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
@@ -2281,7 +2321,7 @@ void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
 	}
 
 	if (shader->data) {
-		shader->data->set_code(p_code);
+		shader->data->set_code(p_code, shader->shader_template);
 	}
 
 	for (Material *E : shader->owners) {
@@ -2601,7 +2641,12 @@ LocalVector<ShaderGLES3::TextureUniformData> get_texture_uniform_data(const Vect
 
 /* Canvas Shader Data */
 
-void CanvasShaderData::set_code(const String &p_code) {
+void CanvasShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported for canvas shaders.");
+	}
+
 	// Initialize and compile the shader.
 
 	code = p_code;
@@ -2772,7 +2817,12 @@ GLES3::MaterialData *GLES3::_create_canvas_material_func(ShaderData *p_shader) {
 ////////////////////////////////////////////////////////////////////////////////
 // SKY SHADER
 
-void SkyShaderData::set_code(const String &p_code) {
+void SkyShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported for sky shaders.");
+	}
+
 	// Initialize and compile the shader.
 
 	code = p_code;
@@ -2914,7 +2964,12 @@ void SkyMaterialData::bind_uniforms() {
 ////////////////////////////////////////////////////////////////////////////////
 // Scene SHADER
 
-void SceneShaderData::set_code(const String &p_code) {
+void SceneShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported on the compatibility render.");
+	}
+
 	// Initialize and compile the shader.
 
 	code = p_code;
@@ -3227,7 +3282,11 @@ void SceneMaterialData::bind_uniforms() {
 
 /* Particles SHADER */
 
-void ParticlesShaderData::set_code(const String &p_code) {
+void ParticlesShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported for particle shaders.");
+	}
 	// Initialize and compile the shader.
 
 	code = p_code;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -142,6 +142,7 @@
 #include "scene/resources/portable_compressed_texture.h"
 #include "scene/resources/resource_format_text.h"
 #include "scene/resources/shader_include.h"
+#include "scene/resources/shader_template.h"
 #include "scene/resources/skeleton_profile.h"
 #include "scene/resources/sky.h"
 #include "scene/resources/style_box.h"
@@ -357,6 +358,9 @@ static Ref<ResourceFormatLoaderCompressedTexture2D> resource_loader_stream_textu
 static Ref<ResourceFormatLoaderCompressedTextureLayered> resource_loader_texture_layered;
 static Ref<ResourceFormatLoaderCompressedTexture3D> resource_loader_texture_3d;
 
+static Ref<ResourceFormatSaverShaderTemplate> resource_saver_shader_template;
+static Ref<ResourceFormatLoaderShaderTemplate> resource_loader_shader_template;
+
 static Ref<ResourceFormatSaverShader> resource_saver_shader;
 static Ref<ResourceFormatLoaderShader> resource_loader_shader;
 
@@ -392,6 +396,14 @@ void register_scene_types() {
 
 	resource_loader_text.instantiate();
 	ResourceLoader::add_resource_format_loader(resource_loader_text, true);
+
+	if constexpr (GD_IS_CLASS_ENABLED(ShaderTemplate)) {
+		resource_saver_shader_template.instantiate();
+		ResourceSaver::add_resource_format_saver(resource_saver_shader_template, true);
+
+		resource_loader_shader_template.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_loader_shader_template, true);
+	}
 
 	if constexpr (GD_IS_CLASS_ENABLED(Shader)) {
 		resource_saver_shader.instantiate();
@@ -730,6 +742,10 @@ void register_scene_types() {
 
 	OS::get_singleton()->yield(); // may take time to init
 #endif // _3D_DISABLED
+
+	/* REGISTER SHADER TEMPLATE */
+
+	GDREGISTER_CLASS(ShaderTemplate);
 
 	/* REGISTER SHADER */
 
@@ -1412,6 +1428,14 @@ void unregister_scene_types() {
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_text);
 	resource_loader_text.unref();
+
+	if constexpr (GD_IS_CLASS_ENABLED(ShaderTemplate)) {
+		ResourceSaver::remove_resource_format_saver(resource_saver_shader_template);
+		resource_saver_shader_template.unref();
+
+		ResourceLoader::remove_resource_format_loader(resource_loader_shader_template);
+		resource_loader_shader_template.unref();
+	}
 
 	if constexpr (GD_IS_CLASS_ENABLED(Shader)) {
 		ResourceSaver::remove_resource_format_saver(resource_saver_shader);

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -32,10 +32,12 @@
 #include "shader.compat.inc"
 
 #include "core/io/file_access.h"
+#include "core/io/resource_loader.h"
 #include "scene/main/scene_tree.h"
 #include "servers/rendering/rendering_server.h"
 #include "servers/rendering/shader_language.h"
 #include "servers/rendering/shader_preprocessor.h"
+#include "shader_template.h"
 #include "texture.h"
 
 #ifdef TOOLS_ENABLED
@@ -127,6 +129,21 @@ void Shader::set_code(const String &p_code) {
 	}
 
 	if (shader_rid.is_valid()) {
+		Ref<ShaderTemplate> new_shader_template;
+
+		String shader_template_path = ShaderLanguage::get_shader_template(preprocessed_code);
+		if (!shader_template_path.is_empty()) {
+			new_shader_template = ResourceLoader::load(shader_template_path);
+		}
+		if (shader_template != new_shader_template) {
+			shader_template = new_shader_template;
+			if (shader_template.is_valid()) {
+				RenderingServer::get_singleton()->shader_set_shader_template(shader_rid, shader_template->get_rid(), true);
+			} else {
+				RenderingServer::get_singleton()->shader_set_shader_template(shader_rid, RID());
+			}
+		}
+
 		RenderingServer::get_singleton()->shader_set_code(shader_rid, preprocessed_code);
 		preprocessed_code = String();
 	}

--- a/scene/resources/shader_template.cpp
+++ b/scene/resources/shader_template.cpp
@@ -1,0 +1,284 @@
+/**************************************************************************/
+/*  shader_template.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "shader_template.h"
+
+#include "core/io/file_access.h"
+#include "main/main.h"
+#include "servers/rendering/rendering_server.h"
+#include "servers/rendering/shader_include_db.h"
+
+void ShaderTemplate::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_mode"), &ShaderTemplate::get_mode);
+
+	ClassDB::bind_method(D_METHOD("set_code", "code"), &ShaderTemplate::set_code);
+	ClassDB::bind_method(D_METHOD("get_code"), &ShaderTemplate::get_code);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_code", "get_code");
+}
+
+String ShaderTemplate::_load_include_file(const String &p_path, const String &p_base_path) {
+	Error err;
+
+	String include = p_path;
+	if (include.is_relative_path()) {
+		include = p_base_path.path_join(include);
+	}
+
+	Ref<FileAccess> file_inc = FileAccess::open(include, FileAccess::READ, &err);
+	if (err != OK) {
+		return String();
+	}
+	return file_inc->get_as_utf8_string();
+}
+
+void ShaderTemplate::_update_template() {
+	String shader_name = get_path();
+	String base_path = "res://"; // We can't guarantee we know folder location, so for now assume paths are relative to project root.
+
+	if (shader_name.is_empty()) {
+		uint64_t id = shader_template.get_id();
+		shader_name = "resource_" + String::num_uint64(id);
+	} else {
+		shader_name = shader_name.replace("res://", "");
+		shader_name = shader_name.replace(".gdtemplate", "");
+		shader_name = shader_name.replace("/", "_");
+		shader_name = shader_name.to_camel_case();
+	}
+
+	int shader = -1;
+	mode = Shader::MODE_MAX;
+	String vertex_shader = "";
+	String fragment_shader = "";
+
+	// Note, we only split out our vertex and fragment shader here.
+	// We do not process includes or compile the shaders.
+	// With templates this happens inside of the rendering engine!
+
+	Vector<String> lines = code.split("\n");
+	String empty_lines;
+	String shader_type;
+	for (int lidx = 0; lidx < lines.size(); lidx++) {
+		String line = lines[lidx];
+		if (line.begins_with("shader_type")) {
+			// Extract shader type
+			int end_pos = line.find(";");
+			if (end_pos != -1) {
+				shader_type = line.substr(12, end_pos - 12);
+			}
+		} else if (line.begins_with("#[")) {
+			int pos = line.find("]");
+			ERR_FAIL_COND_MSG(pos == -1, "Incomplete tag found in shader template - " + String::num_int64(lidx) + ": " + line);
+
+			String tag = line.substr(2, pos - 2);
+			if (tag == "vertex") {
+				ERR_FAIL_COND_MSG(shader != -1, "Unexpected vertex shader in shader template - " + String::num_int64(lidx) + ": " + line);
+				shader = 0;
+				empty_lines = "";
+			} else if (tag == "fragment") {
+				ERR_FAIL_COND_MSG(shader != 0, "Unexpected fragment shader in shader template - " + String::num_int64(lidx) + ": " + line);
+				shader = 1;
+				empty_lines = "";
+			} else {
+				ERR_FAIL_MSG("Unexpected fragment in shader template - " + String::num_int64(lidx) + ": " + line);
+			}
+		} else if (line.begins_with("#include")) {
+			ERR_FAIL_COND_MSG(shader == -1, "Unexpected shader template code - " + String::num_int64(lidx) + ": " + line);
+
+			//process include
+			String include = line.replace("#include", "").strip_edges();
+
+			ERR_FAIL_COND_MSG(!include.begins_with("\"") || !include.ends_with("\""), "Malformed #include syntax, expected #include \"<path>\" - " + String::num_int64(lidx) + ": " + line);
+			include = include.substr(1, include.length() - 2).strip_edges();
+
+			String include_code;
+			if (ShaderIncludeDB::has_built_in_include_file(include)) {
+				// Keep the include as is, we'll insert it later in case our shader supports multiple back-ends.
+				include_code = line;
+			} else {
+				include_code = _load_include_file(include, base_path);
+			}
+
+			ERR_FAIL_COND_MSG(include_code.is_empty(), "Unexpected include file - " + String::num_int64(lidx) + ": " + line);
+
+			if (shader == 0) {
+				vertex_shader += empty_lines + include_code + "\n";
+			} else if (shader == 1) {
+				fragment_shader += empty_lines + include_code + "\n";
+			}
+			empty_lines = "";
+
+		} else if (line.is_empty()) {
+			// Remove any trailing empty lines
+			empty_lines += "\n";
+		} else {
+			ERR_FAIL_COND_MSG(shader == -1, "Unexpected shader template code - " + String::num_int64(lidx) + ": " + line);
+
+			if (shader == 0) {
+				vertex_shader += empty_lines + line + "\n";
+			} else if (shader == 1) {
+				fragment_shader += empty_lines + line + "\n";
+			}
+			empty_lines = "";
+		}
+	}
+
+	if (shader_type == "canvas_item") {
+		mode = Shader::MODE_CANVAS_ITEM;
+	} else if (shader_type == "particles") {
+		mode = Shader::MODE_PARTICLES;
+	} else if (shader_type == "sky") {
+		mode = Shader::MODE_SKY;
+	} else if (shader_type == "fog") {
+		mode = Shader::MODE_FOG;
+	} else if (shader_type == "spatial") {
+		mode = Shader::MODE_SPATIAL;
+	} else {
+		ERR_FAIL_MSG("Unknown shader type in shader template.");
+	}
+
+	ERR_FAIL_COND_MSG(vertex_shader.is_empty(), "No vertex shader code found for this shader template.");
+	ERR_FAIL_COND_MSG(fragment_shader.is_empty(), "No vertex shader code found for this shader template.");
+
+	RenderingServer::get_singleton()->shader_template_set_raster_code(shader_template, vertex_shader, fragment_shader, shader_name);
+}
+
+void ShaderTemplate::set_path(const String &p_path, bool p_take_over) {
+	Resource::set_path(p_path, p_take_over);
+
+	_update_template();
+}
+
+Shader::Mode ShaderTemplate::get_mode() const {
+	return mode;
+}
+
+String ShaderTemplate::get_code() const {
+	return code;
+}
+
+void ShaderTemplate::set_code(const String &p_code) {
+	code = p_code;
+
+	_update_template();
+}
+
+RID ShaderTemplate::get_rid() const {
+	return shader_template;
+}
+
+ShaderTemplate::ShaderTemplate() {
+	shader_template = RenderingServer::get_singleton()->shader_template_create();
+}
+
+ShaderTemplate::~ShaderTemplate() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	RenderingServer::get_singleton()->free_rid(shader_template);
+}
+
+////////////
+
+Ref<Resource> ResourceFormatLoaderShaderTemplate::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+	if (r_error) {
+		*r_error = ERR_FILE_CANT_OPEN;
+	}
+
+	Error error = OK;
+	Vector<uint8_t> buffer = FileAccess::get_file_as_bytes(p_path, &error);
+	if (r_error) {
+		*r_error = error;
+	}
+	ERR_FAIL_COND_V_MSG(error, nullptr, "Cannot load shader: " + p_path);
+
+	String str;
+	if (buffer.size() > 0) {
+		error = str.append_utf8((const char *)buffer.ptr(), buffer.size());
+		if (r_error) {
+			*r_error = error;
+		}
+		ERR_FAIL_COND_V_MSG(error, nullptr, "Cannot parse shader: " + p_path);
+	}
+
+	Ref<ShaderTemplate> shader_template;
+	shader_template.instantiate();
+	shader_template->set_code(str);
+
+	if (r_error) {
+		*r_error = OK;
+	}
+
+	return shader_template;
+}
+
+void ResourceFormatLoaderShaderTemplate::get_recognized_extensions(List<String> *p_extensions) const {
+	p_extensions->push_back("gdtemplate");
+}
+
+bool ResourceFormatLoaderShaderTemplate::handles_type(const String &p_type) const {
+	return (p_type == "ShaderTemplate");
+}
+
+String ResourceFormatLoaderShaderTemplate::get_resource_type(const String &p_path) const {
+	String el = p_path.get_extension().to_lower();
+	if (el == "gdtemplate") {
+		return "ShaderTemplate";
+	}
+	return "";
+}
+
+Error ResourceFormatSaverShaderTemplate::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+	Ref<ShaderTemplate> shader_template = p_resource;
+	ERR_FAIL_COND_V(shader_template.is_null(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(shader_template->get_mode() >= Shader::MODE_MAX, ERR_INVALID_DATA);
+
+	String code = shader_template->get_code();
+
+	Error err;
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+
+	ERR_FAIL_COND_V_MSG(err, err, "Cannot save shader template '" + p_path + "'.");
+
+	file->store_string(code);
+	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
+		return ERR_CANT_CREATE;
+	}
+
+	return OK;
+}
+
+void ResourceFormatSaverShaderTemplate::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
+	if (Object::cast_to<ShaderTemplate>(*p_resource)) {
+		p_extensions->push_back("gdtemplate");
+	}
+}
+
+bool ResourceFormatSaverShaderTemplate::recognize(const Ref<Resource> &p_resource) const {
+	return p_resource->get_class_name() == "ShaderTemplate";
+}

--- a/scene/resources/shader_template.h
+++ b/scene/resources/shader_template.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  shader.h                                                              */
+/*  shader_template.h                                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -33,84 +33,38 @@
 #include "core/io/resource.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
-#include "scene/resources/texture.h"
-#include "shader_include.h"
+#include "shader.h"
 
-class ShaderTemplate;
-
-class Shader : public Resource {
-	GDCLASS(Shader, Resource);
-	OBJ_SAVE_TYPE(Shader);
-
-public:
-	enum Mode {
-		MODE_SPATIAL,
-		MODE_CANVAS_ITEM,
-		MODE_PARTICLES,
-		MODE_SKY,
-		MODE_FOG,
-		MODE_MAX
-	};
+class ShaderTemplate : public Resource {
+	GDCLASS(ShaderTemplate, Resource);
 
 private:
-	mutable RID shader_rid;
-	mutable String preprocessed_code;
-	mutable Mutex shader_rid_mutex;
+	RID shader_template;
 
-	Mode mode = MODE_SPATIAL;
-	Ref<ShaderTemplate> shader_template;
-	HashSet<Ref<ShaderInclude>> include_dependencies;
+	Shader::Mode mode = Shader::MODE_SPATIAL;
 	String code;
-	String include_path;
 
-	HashMap<StringName, HashMap<int, Ref<Texture>>> default_textures;
-
-	void _check_shader_rid() const;
-	void _dependency_changed();
-	void _recompile();
-	virtual void _update_shader() const; //used for visual shader
-	Array _get_shader_uniform_list(bool p_get_groups = false);
+	String _load_include_file(const String &p_path, const String &p_base_path);
+	void _update_template();
 
 protected:
-#ifndef DISABLE_DEPRECATED
-	void _set_default_texture_parameter_bind_compat_95126(const StringName &p_name, const Ref<Texture2D> &p_texture, int p_index = 0);
-	Ref<Texture2D> _get_default_texture_parameter_bind_compat_95126(const StringName &p_name, int p_index = 0) const;
-	static void _bind_compatibility_methods();
-#endif // DISABLE_DEPRECATED
-
 	static void _bind_methods();
 
 public:
-	//void set_mode(Mode p_mode);
-	virtual Mode get_mode() const;
-
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
-	void set_include_path(const String &p_path);
 
-	void set_code(const String &p_code);
+	Shader::Mode get_mode() const;
+
 	String get_code() const;
-
-	void inspect_native_shader_code();
-
-	void get_shader_uniform_list(List<PropertyInfo> *p_params, bool p_get_groups = false) const;
-
-	void set_default_texture_parameter(const StringName &p_name, const Ref<Texture> &p_texture, int p_index = 0);
-	Ref<Texture> get_default_texture_parameter(const StringName &p_name, int p_index = 0) const;
-	void get_default_texture_parameter_list(List<StringName> *r_textures) const;
-
-	virtual bool is_text_shader() const;
+	void set_code(const String &p_code);
 
 	virtual RID get_rid() const override;
 
-	Shader();
-	~Shader();
+	ShaderTemplate();
+	~ShaderTemplate();
 };
 
-VARIANT_ENUM_CAST(Shader::Mode);
-
-class ResourceFormatLoaderShader : public ResourceFormatLoader {
-	GDSOFTCLASS(ResourceFormatLoaderShader, ResourceFormatLoader);
-
+class ResourceFormatLoaderShaderTemplate : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
@@ -118,9 +72,7 @@ public:
 	virtual String get_resource_type(const String &p_path) const override;
 };
 
-class ResourceFormatSaverShader : public ResourceFormatSaver {
-	GDSOFTCLASS(ResourceFormatSaverShader, ResourceFormatSaver);
-
+class ResourceFormatSaverShaderTemplate : public ResourceFormatSaver {
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;

--- a/servers/rendering/dummy/storage/material_storage.h
+++ b/servers/rendering/dummy/storage/material_storage.h
@@ -83,6 +83,14 @@ public:
 	virtual void global_shader_parameters_instance_free(RID p_instance) override {}
 	virtual void global_shader_parameters_instance_update(RID p_instance, int p_index, const Variant &p_value, int p_flags_count = 0) override {}
 
+	/* SHADER TEMPLATE API */
+
+	virtual RID shader_template_allocate() override { return RID(); }
+	virtual void shader_template_initialize(RID p_rid) override {}
+	virtual void shader_template_free(RID p_rid) override {}
+
+	virtual void shader_template_set_raster_code(RID p_template_shader, const String &p_vertex_code, const String &p_fragment_code, const String &p_name) override {}
+
 	/* SHADER API */
 
 	bool owns_shader(RID p_rid) { return shader_owner.owns(p_rid); }
@@ -91,6 +99,7 @@ public:
 	virtual void shader_initialize(RID p_rid, bool p_embedded) override;
 	virtual void shader_free(RID p_rid) override;
 
+	virtual void shader_set_shader_template(RID p_shader, RID p_shader_template = RID(), bool p_clear_code = false) override {}
 	virtual void shader_set_code(RID p_shader, const String &p_code) override;
 	virtual void shader_set_path_hint(RID p_shader, const String &p_code) override {}
 

--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -353,7 +353,12 @@ void Fog::free_fog_shader() {
 	}
 }
 
-void Fog::FogShaderData::set_code(const String &p_code) {
+void Fog::FogShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported for fog shaders.");
+	}
+
 	//compile
 
 	code = p_code;

--- a/servers/rendering/renderer_rd/environment/fog.h
+++ b/servers/rendering/renderer_rd/environment/fog.h
@@ -210,7 +210,7 @@ private:
 
 		bool uses_time = false;
 
-		virtual void set_code(const String &p_Code);
+		virtual void set_code(const String &p_Code, RID p_shader_template = RID());
 		virtual bool is_animated() const;
 		virtual bool casts_shadows() const;
 		virtual RS::ShaderNativeSourceCode get_native_source_code() const;

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -51,7 +51,12 @@ using namespace RendererRD;
 ////////////////////////////////////////////////////////////////////////////////
 // SKY SHADER
 
-void SkyRD::SkyShaderData::set_code(const String &p_code) {
+void SkyRD::SkyShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported for sky shaders.");
+	}
+
 	//compile
 
 	code = p_code;

--- a/servers/rendering/renderer_rd/environment/sky.h
+++ b/servers/rendering/renderer_rd/environment/sky.h
@@ -124,7 +124,7 @@ private:
 		bool uses_quarter_res = false;
 		bool uses_light = false;
 
-		virtual void set_code(const String &p_Code);
+		virtual void set_code(const String &p_Code, RID p_shader_template = RID());
 		virtual bool is_animated() const;
 		virtual bool casts_shadows() const;
 		virtual RS::ShaderNativeSourceCode get_native_source_code() const;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1843,7 +1843,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 		if (p_render_data->scene_data->view_count > 1) {
 			color_pass_flags |= COLOR_PASS_FLAG_MULTIVIEW;
 			// Try enabling here in case is_xr_enabled() returns false.
-			scene_shader.shader.enable_group(SceneShaderForwardClustered::SHADER_GROUP_MULTIVIEW);
+			RendererRD::MaterialStorage::get_singleton()->shader_template_enable_group_on_all(SceneShaderForwardClustered::SHADER_GROUP_MULTIVIEW);
 
 			// Indicate pipelines for multiview are required.
 			global_pipeline_data_required.use_multiview = true;

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -37,7 +37,73 @@
 
 using namespace RendererSceneRenderImplementation;
 
-void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
+void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// get shader template
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+
+	shader_template = p_shader_template;
+	if (shader_template.is_null()) {
+		shader_template = SceneShaderForwardClustered::singleton->default_shader_template;
+	}
+	ERR_FAIL_COND(shader_template.is_null());
+
+	if (!material_storage->shader_template_is_initialized(shader_template)) {
+		// For our default template shader, this will be called when our default material gets created.
+
+		Vector<ShaderRD::VariantDefine> shader_versions;
+		for (uint32_t ubershader = 0; ubershader < 2; ubershader++) {
+			const String base_define = ubershader ? "\n#define UBERSHADER\n" : "";
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_BASE, base_define + "\n#define MODE_RENDER_DEPTH\n", true)); // SHADER_VERSION_DEPTH_PASS
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_BASE, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_DUAL_PARABOLOID\n", true)); // SHADER_VERSION_DEPTH_PASS_DP
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_BASE, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_NORMAL_ROUGHNESS\n", true)); // SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_ADVANCED, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_NORMAL_ROUGHNESS\n#define MODE_RENDER_VOXEL_GI\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS_AND_VOXEL_GI
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_MULTIVIEW, base_define + "\n#define USE_MULTIVIEW\n#define MODE_RENDER_DEPTH\n", false)); // SHADER_VERSION_DEPTH_PASS_MULTIVIEW
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_MULTIVIEW, base_define + "\n#define USE_MULTIVIEW\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_NORMAL_ROUGHNESS\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS_MULTIVIEW
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_ADVANCED_MULTIVIEW, base_define + "\n#define USE_MULTIVIEW\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_NORMAL_ROUGHNESS\n#define MODE_RENDER_VOXEL_GI\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS_AND_VOXEL_GI_MULTIVIEW
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_ADVANCED, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_MATERIAL\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_MATERIAL
+			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_ADVANCED, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_SDF\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_SDF
+		}
+
+		Vector<String> color_pass_flags = {
+			"\n#define UBERSHADER\n", // SHADER_COLOR_PASS_FLAG_UBERSHADER
+			"\n#define MODE_SEPARATE_SPECULAR\n", // SHADER_COLOR_PASS_FLAG_SEPARATE_SPECULAR
+			"\n#define USE_LIGHTMAP\n", // SHADER_COLOR_PASS_FLAG_LIGHTMAP
+			"\n#define USE_MULTIVIEW\n", // SHADER_COLOR_PASS_FLAG_MULTIVIEW
+			"\n#define MOTION_VECTORS\n", // SHADER_COLOR_PASS_FLAG_MOTION_VECTORS
+		};
+
+		for (int i = 0; i < SHADER_COLOR_PASS_FLAG_COUNT; i++) {
+			String version_flags = "";
+			for (int j = 0; (1 << j) < SHADER_COLOR_PASS_FLAG_COUNT; j += 1) {
+				if ((1 << j) & i) {
+					version_flags += color_pass_flags[j];
+				}
+			}
+
+			// Assign a group based on what features this pass contains.
+			ShaderGroup group = SHADER_GROUP_BASE;
+			bool advanced_group = (i & SHADER_COLOR_PASS_FLAG_SEPARATE_SPECULAR) || (i & SHADER_COLOR_PASS_FLAG_LIGHTMAP) || (i & SHADER_COLOR_PASS_FLAG_MOTION_VECTORS);
+			bool multiview_group = i & SHADER_COLOR_PASS_FLAG_MULTIVIEW;
+			if (advanced_group && multiview_group) {
+				group = SHADER_GROUP_ADVANCED_MULTIVIEW;
+			} else if (advanced_group) {
+				group = SHADER_GROUP_ADVANCED;
+			} else if (multiview_group) {
+				group = SHADER_GROUP_MULTIVIEW;
+			}
+
+			shader_versions.push_back(ShaderRD::VariantDefine(group, version_flags, false));
+		}
+
+		Vector<uint64_t> dynamic_buffers;
+		dynamic_buffers.push_back(ShaderRD::DynamicBuffer::encode(RenderForwardClustered::RENDER_PASS_UNIFORM_SET, 2));
+		material_storage->shader_template_shader_initialize(shader_template, shader_versions, SceneShaderForwardClustered::singleton->default_defines, Vector<RD::PipelineImmutableSampler>(), dynamic_buffers);
+
+		if (RendererCompositorRD::get_singleton()->is_xr_enabled()) {
+			material_storage->shader_template_enable_group_on_all(SHADER_GROUP_MULTIVIEW);
+		}
+	}
+
 	//compile
 
 	code = p_code;
@@ -175,14 +241,14 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 
 	if (err != OK) {
 		if (version.is_valid()) {
-			SceneShaderForwardClustered::singleton->shader.version_free(version);
+			material_storage->shader_template_version_free(shader_template, version);
 			version = RID();
 		}
 		ERR_FAIL_MSG("Shader compilation failed.");
 	}
 
 	if (version.is_null()) {
-		version = SceneShaderForwardClustered::singleton->shader.version_create(false);
+		version = material_storage->shader_template_version_create(shader_template, false);
 	}
 
 	depth_draw = DepthDraw(depth_drawi);
@@ -227,7 +293,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	print_line("\n**vertex_globals:\n" + gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX]);
 	print_line("\n**fragment_globals:\n" + gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT]);
 #endif
-	SceneShaderForwardClustered::singleton->shader.version_set_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines);
+	material_storage->shader_template_version_set_code(shader_template, version, gen_code.code, gen_code.uniforms, gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines);
 
 	ubo_size = gen_code.uniform_total_size;
 	ubo_offsets = gen_code.uniform_offsets;
@@ -257,7 +323,8 @@ bool SceneShaderForwardClustered::ShaderData::casts_shadows() const {
 
 RS::ShaderNativeSourceCode SceneShaderForwardClustered::ShaderData::get_native_source_code() const {
 	if (version.is_valid()) {
-		return SceneShaderForwardClustered::singleton->shader.version_get_native_source_code(version);
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		return material_storage->shader_template_version_get_native_source_code(shader_template, version);
 	} else {
 		return RS::ShaderNativeSourceCode();
 	}
@@ -265,7 +332,8 @@ RS::ShaderNativeSourceCode SceneShaderForwardClustered::ShaderData::get_native_s
 
 Pair<ShaderRD *, RID> SceneShaderForwardClustered::ShaderData::get_native_shader_and_version() const {
 	if (version.is_valid()) {
-		return { &SceneShaderForwardClustered::singleton->shader, version };
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		return { material_storage->shader_template_get_shader(shader_template), version };
 	} else {
 		return {};
 	}
@@ -502,8 +570,9 @@ RD::PolygonCullMode SceneShaderForwardClustered::ShaderData::get_cull_mode_from_
 
 RID SceneShaderForwardClustered::ShaderData::_get_shader_variant(uint16_t p_shader_version) const {
 	if (version.is_valid()) {
-		ERR_FAIL_NULL_V(SceneShaderForwardClustered::singleton, RID());
-		return SceneShaderForwardClustered::singleton->shader.version_get_shader(version, p_shader_version);
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		ERR_FAIL_NULL_V(material_storage, RID());
+		return material_storage->shader_template_version_get_shader(shader_template, version, p_shader_version);
 	} else {
 		return RID();
 	}
@@ -536,8 +605,9 @@ uint64_t SceneShaderForwardClustered::ShaderData::get_vertex_input_mask(Pipeline
 
 bool SceneShaderForwardClustered::ShaderData::is_valid() const {
 	if (version.is_valid()) {
-		ERR_FAIL_NULL_V(SceneShaderForwardClustered::singleton, false);
-		return SceneShaderForwardClustered::singleton->shader.version_is_valid(version);
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		ERR_FAIL_NULL_V(material_storage, false);
+		return material_storage->shader_template_version_is_valid(shader_template, version);
 	} else {
 		return false;
 	}
@@ -553,8 +623,10 @@ SceneShaderForwardClustered::ShaderData::~ShaderData() {
 	pipeline_hash_map.clear_pipelines();
 
 	if (version.is_valid()) {
-		ERR_FAIL_NULL(SceneShaderForwardClustered::singleton);
-		SceneShaderForwardClustered::singleton->shader.version_free(version);
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		ERR_FAIL_NULL(material_storage);
+
+		material_storage->shader_template_version_free(shader_template, version);
 	}
 }
 
@@ -575,7 +647,8 @@ void SceneShaderForwardClustered::MaterialData::set_next_pass(RID p_pass) {
 
 bool SceneShaderForwardClustered::MaterialData::update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty) {
 	if (shader_data->version.is_valid()) {
-		RID shader_rid = SceneShaderForwardClustered::singleton->shader.version_get_shader(shader_data->version, 0);
+		RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+		RID shader_rid = material_storage->shader_template_version_get_shader(shader_data->shader_template, shader_data->version, 0);
 
 		MutexLock lock(SceneShaderForwardClustered::singleton_mutex);
 		return update_parameters_uniform_set(p_parameters, p_uniform_dirty, p_textures_dirty, shader_data->uniforms, shader_data->ubo_offsets.ptr(), shader_data->texture_uniforms, shader_data->default_texture_params, shader_data->ubo_size, uniform_set, shader_rid, RenderForwardClustered::MATERIAL_UNIFORM_SET, true, true);
@@ -616,64 +689,18 @@ SceneShaderForwardClustered::~SceneShaderForwardClustered() {
 	material_storage->material_free(overdraw_material);
 	material_storage->material_free(default_material);
 	material_storage->material_free(debug_shadow_splits_material);
+
+	material_storage->shader_template_free(default_shader_template);
 }
 
 void SceneShaderForwardClustered::init(const String p_defines) {
 	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
 
 	{
-		Vector<ShaderRD::VariantDefine> shader_versions;
-		for (uint32_t ubershader = 0; ubershader < 2; ubershader++) {
-			const String base_define = ubershader ? "\n#define UBERSHADER\n" : "";
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_BASE, base_define + "\n#define MODE_RENDER_DEPTH\n", true)); // SHADER_VERSION_DEPTH_PASS
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_BASE, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_DUAL_PARABOLOID\n", true)); // SHADER_VERSION_DEPTH_PASS_DP
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_BASE, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_NORMAL_ROUGHNESS\n", true)); // SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_ADVANCED, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_NORMAL_ROUGHNESS\n#define MODE_RENDER_VOXEL_GI\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS_AND_VOXEL_GI
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_MULTIVIEW, base_define + "\n#define USE_MULTIVIEW\n#define MODE_RENDER_DEPTH\n", false)); // SHADER_VERSION_DEPTH_PASS_MULTIVIEW
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_MULTIVIEW, base_define + "\n#define USE_MULTIVIEW\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_NORMAL_ROUGHNESS\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS_MULTIVIEW
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_ADVANCED_MULTIVIEW, base_define + "\n#define USE_MULTIVIEW\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_NORMAL_ROUGHNESS\n#define MODE_RENDER_VOXEL_GI\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS_AND_VOXEL_GI_MULTIVIEW
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_ADVANCED, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_MATERIAL\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_MATERIAL
-			shader_versions.push_back(ShaderRD::VariantDefine(SHADER_GROUP_ADVANCED, base_define + "\n#define MODE_RENDER_DEPTH\n#define MODE_RENDER_SDF\n", false)); // SHADER_VERSION_DEPTH_PASS_WITH_SDF
-		}
-
-		Vector<String> color_pass_flags = {
-			"\n#define UBERSHADER\n", // SHADER_COLOR_PASS_FLAG_UBERSHADER
-			"\n#define MODE_SEPARATE_SPECULAR\n", // SHADER_COLOR_PASS_FLAG_SEPARATE_SPECULAR
-			"\n#define USE_LIGHTMAP\n", // SHADER_COLOR_PASS_FLAG_LIGHTMAP
-			"\n#define USE_MULTIVIEW\n", // SHADER_COLOR_PASS_FLAG_MULTIVIEW
-			"\n#define MOTION_VECTORS\n", // SHADER_COLOR_PASS_FLAG_MOTION_VECTORS
-		};
-
-		for (int i = 0; i < SHADER_COLOR_PASS_FLAG_COUNT; i++) {
-			String version = "";
-			for (int j = 0; (1 << j) < SHADER_COLOR_PASS_FLAG_COUNT; j += 1) {
-				if ((1 << j) & i) {
-					version += color_pass_flags[j];
-				}
-			}
-
-			// Assign a group based on what features this pass contains.
-			ShaderGroup group = SHADER_GROUP_BASE;
-			bool advanced_group = (i & SHADER_COLOR_PASS_FLAG_SEPARATE_SPECULAR) || (i & SHADER_COLOR_PASS_FLAG_LIGHTMAP) || (i & SHADER_COLOR_PASS_FLAG_MOTION_VECTORS);
-			bool multiview_group = i & SHADER_COLOR_PASS_FLAG_MULTIVIEW;
-			if (advanced_group && multiview_group) {
-				group = SHADER_GROUP_ADVANCED_MULTIVIEW;
-			} else if (advanced_group) {
-				group = SHADER_GROUP_ADVANCED;
-			} else if (multiview_group) {
-				group = SHADER_GROUP_MULTIVIEW;
-			}
-
-			shader_versions.push_back(ShaderRD::VariantDefine(group, version, false));
-		}
-
-		Vector<uint64_t> dynamic_buffers;
-		dynamic_buffers.push_back(ShaderRD::DynamicBuffer::encode(RenderForwardClustered::RENDER_PASS_UNIFORM_SET, 2));
-		shader.initialize(shader_versions, p_defines, Vector<RD::PipelineImmutableSampler>(), dynamic_buffers);
-
-		if (RendererCompositorRD::get_singleton()->is_xr_enabled()) {
-			shader.enable_group(SHADER_GROUP_MULTIVIEW);
-		}
+		default_defines = p_defines;
+		default_shader_template = material_storage->shader_template_allocate();
+		material_storage->shader_template_initialize(default_shader_template);
+		material_storage->shader_template_set_shader(default_shader_template, memnew(SceneForwardClusteredShaderRD));
 	}
 
 	material_storage->shader_set_data_request_function(RendererRD::MaterialStorage::SHADER_TYPE_3D, _create_shader_funcs);
@@ -991,25 +1018,30 @@ void SceneShaderForwardClustered::set_default_specialization(const ShaderSpecial
 }
 
 void SceneShaderForwardClustered::enable_multiview_shader_group() {
-	shader.enable_group(SHADER_GROUP_MULTIVIEW);
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+	material_storage->shader_template_enable_group_on_all(SHADER_GROUP_MULTIVIEW);
 }
 
 void SceneShaderForwardClustered::enable_advanced_shader_group(bool p_needs_multiview) {
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+
 	if (p_needs_multiview || RendererCompositorRD::get_singleton()->is_xr_enabled()) {
-		shader.enable_group(SHADER_GROUP_ADVANCED_MULTIVIEW);
+		material_storage->shader_template_enable_group_on_all(SHADER_GROUP_ADVANCED_MULTIVIEW);
 	}
-	shader.enable_group(SHADER_GROUP_ADVANCED);
+	material_storage->shader_template_enable_group_on_all(SHADER_GROUP_ADVANCED);
 }
 
 bool SceneShaderForwardClustered::is_multiview_shader_group_enabled() const {
-	return shader.is_group_enabled(SHADER_GROUP_MULTIVIEW);
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+	return material_storage->shader_template_is_any_group_enabled(SHADER_GROUP_MULTIVIEW);
 }
 
 bool SceneShaderForwardClustered::is_advanced_shader_group_enabled(bool p_multiview) const {
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
 	if (p_multiview) {
-		return shader.is_group_enabled(SHADER_GROUP_ADVANCED_MULTIVIEW);
+		return material_storage->shader_template_is_any_group_enabled(SHADER_GROUP_ADVANCED_MULTIVIEW);
 	} else {
-		return shader.is_group_enabled(SHADER_GROUP_ADVANCED);
+		return material_storage->shader_template_is_any_group_enabled(SHADER_GROUP_ADVANCED);
 	}
 }
 

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -215,6 +215,7 @@ public:
 		void _create_pipeline(PipelineKey p_pipeline_key);
 		PipelineHashMapRD<PipelineKey, ShaderData, void (ShaderData::*)(PipelineKey)> pipeline_hash_map;
 
+		RID shader_template;
 		RID version;
 
 		static const uint32_t VERTEX_INPUT_MASKS_SIZE = ShaderVersion::SHADER_VERSION_COLOR_PASS * 2 + SHADER_COLOR_PASS_FLAG_COUNT;
@@ -296,7 +297,7 @@ public:
 			return !uses_particle_trails && !writes_modelview_or_projection && !uses_vertex && !uses_position && !uses_discard && !uses_depth_prepass_alpha && !uses_alpha_clip && !uses_alpha_antialiasing && backface_culling && !uses_point_size && !uses_world_coordinates && !wireframe && !uses_z_clip_scale && !stencil_enabled;
 		}
 
-		virtual void set_code(const String &p_Code);
+		virtual void set_code(const String &p_Code, RID p_shader_template = RID());
 
 		virtual bool is_animated() const;
 		virtual bool casts_shadows() const;
@@ -340,9 +341,10 @@ public:
 		return static_cast<SceneShaderForwardClustered *>(singleton)->_create_material_func(static_cast<ShaderData *>(p_shader));
 	}
 
-	SceneForwardClusteredShaderRD shader;
+	String default_defines;
 	ShaderCompiler compiler;
 
+	RID default_shader_template;
 	RID default_shader;
 	RID default_material;
 	RID overdraw_material_shader;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -221,6 +221,7 @@ public:
 		void _create_pipeline(PipelineKey p_pipeline_key);
 		PipelineHashMapRD<PipelineKey, ShaderData, void (ShaderData::*)(PipelineKey)> pipeline_hash_map;
 
+		RID shader_template;
 		RID version;
 
 		static const uint32_t VERTEX_INPUT_MASKS_SIZE = SHADER_VERSION_MAX * 2;
@@ -300,7 +301,7 @@ public:
 			return !uses_particle_trails && !writes_modelview_or_projection && !uses_vertex && !uses_discard && !uses_depth_prepass_alpha && !uses_alpha_clip && !uses_alpha_antialiasing && !uses_point_size && !uses_world_coordinates && !wireframe && !stencil_enabled && backface_culling;
 		}
 
-		virtual void set_code(const String &p_Code);
+		virtual void set_code(const String &p_Code, RID p_shader_template = RID());
 		virtual bool is_animated() const;
 		virtual bool casts_shadows() const;
 		virtual RS::ShaderNativeSourceCode get_native_source_code() const;
@@ -342,10 +343,11 @@ public:
 		return static_cast<SceneShaderForwardMobile *>(singleton)->_create_material_func(static_cast<ShaderData *>(p_shader));
 	}
 
-	SceneForwardMobileShaderRD shader;
+	String default_defines;
 	ShaderCompiler compiler;
 	bool use_fp16 = false;
 
+	RID default_shader_template;
 	RID default_shader;
 	RID default_material;
 	RID overdraw_material_shader;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1532,7 +1532,12 @@ void RendererCanvasRenderRD::CanvasShaderData::_create_pipeline(PipelineKey p_pi
 	pipeline_hash_map.add_compiled_pipeline(p_pipeline_key.hash(), pipeline);
 }
 
-void RendererCanvasRenderRD::CanvasShaderData::set_code(const String &p_code) {
+void RendererCanvasRenderRD::CanvasShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported for Canvas shaders.");
+	}
+
 	//compile
 
 	code = p_code;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -166,7 +166,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 
 		void _clear_vertex_input_mask_cache();
 		void _create_pipeline(PipelineKey p_pipeline_key);
-		virtual void set_code(const String &p_Code);
+		virtual void set_code(const String &p_Code, RID p_shader_template = RID());
 		virtual bool is_animated() const;
 		virtual bool casts_shadows() const;
 		virtual RS::ShaderNativeSourceCode get_native_source_code() const;

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -38,7 +38,15 @@
 #include "core/templates/self_list.h"
 #include "servers/rendering/rendering_server.h"
 
+namespace RendererRD {
+
+class MaterialStorage;
+
+}
+
 class ShaderRD {
+	friend class RendererRD::MaterialStorage;
+
 public:
 	struct VariantDefine {
 		int group = 0;

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1675,7 +1675,12 @@ bool ParticlesStorage::particles_is_inactive(RID p_particles) const {
 
 /* Particles SHADER */
 
-void ParticlesStorage::ParticlesShaderData::set_code(const String &p_code) {
+void ParticlesStorage::ParticlesShaderData::set_code(const String &p_code, RID p_shader_template) {
+	// Shader template isn't supported here yet.
+	if (p_shader_template.is_valid()) {
+		WARN_PRINT_ONCE("Shader templates are not supported for particle shaders.");
+	}
+
 	ParticlesStorage *particles_storage = ParticlesStorage::get_singleton();
 	//compile
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -361,7 +361,7 @@ private:
 		bool userdatas_used[ParticlesShader::MAX_USERDATAS] = {};
 		uint32_t userdata_count = 0;
 
-		virtual void set_code(const String &p_Code);
+		virtual void set_code(const String &p_Code, RID p_shader_template = RID());
 		virtual bool is_animated() const;
 		virtual bool casts_shadows() const;
 		virtual RS::ShaderNativeSourceCode get_native_source_code() const;

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2369,9 +2369,15 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(CUBEMAP_LAYER_FRONT);
 	BIND_ENUM_CONSTANT(CUBEMAP_LAYER_BACK);
 
+	/* SHADER TEMPLATE */
+
+	ClassDB::bind_method(D_METHOD("shader_template_create"), &RenderingServer::shader_template_create);
+	ClassDB::bind_method(D_METHOD("shader_template_set_raster_code", "shader_template", "vertex_code", "fragment_code", "name"), &RenderingServer::shader_template_set_raster_code);
+
 	/* SHADER */
 
 	ClassDB::bind_method(D_METHOD("shader_create"), &RenderingServer::shader_create);
+	ClassDB::bind_method(D_METHOD("shader_set_shader_template", "shader", "shader_template", "clear_code"), &RenderingServer::shader_set_shader_template, DEFVAL(RID()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("shader_set_code", "shader", "code"), &RenderingServer::shader_set_code);
 	ClassDB::bind_method(D_METHOD("shader_set_path_hint", "shader", "path"), &RenderingServer::shader_set_path_hint);
 	ClassDB::bind_method(D_METHOD("shader_get_code", "shader"), &RenderingServer::shader_get_code);

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -210,6 +210,12 @@ public:
 		PIPELINE_SOURCE_MAX
 	};
 
+	/* SHADER TEMPLATE API */
+
+	virtual RID shader_template_create() = 0;
+
+	virtual void shader_template_set_raster_code(RID p_shader_template, const String &p_vertex_code, const String &p_fragment_code, const String &p_name) = 0;
+
 	/* SHADER API */
 
 	enum ShaderMode {
@@ -230,6 +236,7 @@ public:
 	virtual RID shader_create() = 0;
 	virtual RID shader_create_from_code(const String &p_code, const String &p_path_hint = String()) = 0;
 
+	virtual void shader_set_shader_template(RID p_shader, RID p_shader_template = RID(), bool p_clear_code = false) = 0;
 	virtual void shader_set_code(RID p_shader, const String &p_code) = 0;
 	virtual void shader_set_path_hint(RID p_shader, const String &p_path) = 0;
 	virtual String shader_get_code(RID p_shader) const = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -244,6 +244,10 @@ public:
 #define ServerName RendererMaterialStorage
 #define server_name RSG::material_storage
 
+	FUNCRIDSPLIT(shader_template)
+
+	FUNC4(shader_template_set_raster_code, RID, const String &, const String &, const String &)
+
 	virtual RID shader_create() override {
 		RID ret = RSG::material_storage->shader_allocate();
 		if (Thread::get_caller_id() == server_thread) {
@@ -253,6 +257,8 @@ public:
 		}
 		return ret;
 	}
+
+	// TODO probably need a variant here WITH template.
 
 	virtual RID shader_create_from_code(const String &p_code, const String &p_path_hint = String()) override {
 		RID shader = RSG::material_storage->shader_allocate();
@@ -274,6 +280,7 @@ public:
 		return shader;
 	}
 
+	FUNC3(shader_set_shader_template, RID, RID, bool)
 	FUNC2(shader_set_code, RID, const String &)
 	FUNC2(shader_set_path_hint, RID, const String &)
 	FUNC1RC(String, shader_get_code, RID)

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -196,6 +196,7 @@ public:
 		TK_CURSOR,
 		TK_ERROR,
 		TK_EOF,
+		TK_SHADER_TEMPLATE,
 		TK_MAX
 	};
 
@@ -1055,6 +1056,7 @@ private:
 	StringName last_name;
 	bool is_shader_inc = false;
 
+	String shader_template;
 	String current_uniform_group_name;
 	String current_uniform_subgroup_name;
 
@@ -1249,6 +1251,7 @@ public:
 	void clear();
 
 	static String get_shader_type(const String &p_code);
+	static String get_shader_template(const String &p_code);
 	static bool is_builtin_func_out_parameter(const String &p_name, int p_param);
 
 	struct ShaderCompileInfo {

--- a/servers/rendering/storage/material_storage.h
+++ b/servers/rendering/storage/material_storage.h
@@ -54,11 +54,21 @@ public:
 	virtual void global_shader_parameters_instance_free(RID p_instance) = 0;
 	virtual void global_shader_parameters_instance_update(RID p_instance, int p_index, const Variant &p_value, int p_flags_count = 0) = 0;
 
+	/* SHADER TEMPLATE API */
+
+	virtual RID shader_template_allocate() = 0;
+	virtual void shader_template_initialize(RID p_rid) = 0;
+	virtual void shader_template_free(RID p_rid) = 0;
+
+	virtual void shader_template_set_raster_code(RID p_template_shader, const String &p_vertex_code, const String &p_fragment_code, const String &p_name) = 0;
+
 	/* SHADER API */
+
 	virtual RID shader_allocate() = 0;
 	virtual void shader_initialize(RID p_rid, bool p_embedded = true) = 0;
 	virtual void shader_free(RID p_rid) = 0;
 
+	virtual void shader_set_shader_template(RID p_shader, RID p_shader_template = RID(), bool p_clear_code = false) = 0;
 	virtual void shader_set_code(RID p_shader, const String &p_code) = 0;
 	virtual void shader_set_path_hint(RID p_shader, const String &p_path) = 0;
 	virtual String shader_get_code(RID p_shader) const = 0;


### PR DESCRIPTION
A small extension to allow nesting `#include` directives in custom include files. Detects and handles malformed `#include`, invalid files and infinitely recursive `#include` gracefully.

Shader authors often want to have multiple levels of `#include`, especially as the project gets more complex.